### PR TITLE
fix config

### DIFF
--- a/tetrad/pkg/cniserver/cniserver.go
+++ b/tetrad/pkg/cniserver/cniserver.go
@@ -41,6 +41,7 @@ func NewServer(socketPath string, opt Options) (Server, error) {
 	if err := os.MkdirAll(filepath.Dir(socketPath), 0700); err != nil {
 		return nil, fmt.Errorf("failed to mkdirall %s: %w", socketPath, err)
 	}
+	_ = os.Remove(socketPath)
 
 	l, err := net.Listen("unix", socketPath)
 


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
