### PR TITLE
Add a route-pods plugin to configure routes to pods from host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,10 @@ tetra-pod-ipam: bin
 hostvrf: bin
 	CGO_ENABLED=0 go build -o ./bin ./tetracni/cmd/hostvrf
 
-cni-plugins: tetra-extra-routes tetra-pod-ipam hostvrf
+route-pods: bin
+	CGO_ENABLED=0 go build -o ./bin ./tetracni/cmd/route-pods
+
+cni-plugins: tetra-extra-routes tetra-pod-ipam hostvrf route-pods
 
 .PHONY: test
 test: envtest ## Run tests.

--- a/tetracni/cmd/route-pods/conf.go
+++ b/tetracni/cmd/route-pods/conf.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+type Conf struct {
+	types.NetConf
+
+	HostVeth      string `json:"hostVeth"`
+	PeerVeth      string `json:"peerVeth"`
+	Firewall      string `json:"firewall"`
+	IPTablesChain string `json:"iptablesChain"`
+}
+
+const (
+	FirewallIPTables = "iptables"
+	FirewallNever    = "never"
+)
+
+func loadConfig(stdin []byte) (*Conf, *current.Result, error) {
+	var conf Conf
+	if err := json.Unmarshal(stdin, &conf); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal stsin: %w", err)
+	}
+
+	if err := version.ParsePrevResult(&conf.NetConf); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse prev result: %w", err)
+	}
+
+	result, err := current.NewResultFromResult(conf.PrevResult)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to retrieve result: %w", err)
+	}
+
+	if conf.HostVeth == "" {
+		conf.HostVeth = "tetrapod-host"
+	}
+
+	if conf.PeerVeth == "" {
+		conf.PeerVeth = "tetrapod-net"
+	}
+
+	switch conf.Firewall {
+	case "":
+		conf.Firewall = FirewallIPTables
+	case FirewallIPTables:
+		// ok
+	default:
+		return nil, nil, fmt.Errorf("unknown firewall mode: %s", conf.Firewall)
+	}
+
+	if conf.IPTablesChain == "" {
+		conf.IPTablesChain = "TETRAPOD"
+	}
+
+	return &conf, result, nil
+}

--- a/tetracni/cmd/route-pods/iptables.go
+++ b/tetracni/cmd/route-pods/iptables.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	iptablesFilterTable = "filter"
+)
+
+var (
+	iptablesChains = []string{
+		"INPUT",
+		"OUTPUT",
+		"FORWARD",
+	}
+)
+
+func setUpIPTables(ipt *iptables.IPTables, hostVeth *netlink.Veth, redirectedChain string) error {
+	exists, err := ipt.ChainExists(iptablesFilterTable, redirectedChain)
+
+	if err != nil {
+		return fmt.Errorf("failed to check the existence of %s: %w", redirectedChain, err)
+	}
+
+	if !exists {
+		if err := ipt.NewChain(iptablesFilterTable, redirectedChain); err != nil {
+			return fmt.Errorf("failed to add a chain %s: %w", redirectedChain, err)
+		}
+	}
+
+	for _, chain := range iptablesChains {
+		rule := fmt.Sprintf("-j %s", redirectedChain)
+
+		if err := ipt.AppendUnique(iptablesFilterTable, chain, rule); err != nil {
+			return fmt.Errorf("failed to add a rule %s to %s/%s: %w", rule, iptablesFilterTable, chain, err)
+		}
+	}
+
+	rules := []string{
+		fmt.Sprintf("-o %s -j ACCEPT", hostVeth.Name),
+		fmt.Sprintf("-i %s -m state --state RELATED,ESTABLISHED -j ACCEPT", hostVeth.Name),
+		fmt.Sprintf("-i %s -j REJECT --reject-with icmp-port-unreachable", hostVeth.Name),
+	}
+
+	if err := ipt.AppendUnique(iptablesFilterTable, redirectedChain, rules...); err != nil {
+		return fmt.Errorf("failed to append rules %s to %s/%s", strings.Join(rules, ", "), iptablesFilterTable, redirectedChain)
+	}
+
+	return nil
+}
+
+func setUpFirewall(hostVeth *netlink.Veth, conf *Conf) error {
+	switch conf.Firewall {
+	case FirewallNever:
+		return nil
+	case FirewallIPTables:
+		ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+
+		if err != nil {
+			return fmt.Errorf("failed to set up iptables: %w", err)
+		}
+
+		if err := setUpIPTables(ipt, hostVeth, conf.IPTablesChain); err != nil {
+			return fmt.Errorf("failed to set up iptables for v4: %w", err)
+		}
+
+		ipt, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+
+		if err != nil {
+			return fmt.Errorf("failed to set up iptables: %w", err)
+		}
+
+		if err := setUpIPTables(ipt, hostVeth, conf.IPTablesChain); err != nil {
+			return fmt.Errorf("failed to set up iptables for v4: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/tetracni/cmd/route-pods/main.go
+++ b/tetracni/cmd/route-pods/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
+	bv "github.com/containernetworking/plugins/pkg/utils/buildversion"
+	"github.com/seancfoley/ipaddress-go/ipaddr"
+	"github.com/vishvananda/netlink"
+)
+
+func main() {
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.All, bv.BuildString("hostvrf"))
+}
+
+func findVeth(hostVethName, peerVethName string) (hostVeth, peerVeth *netlink.Veth, err error) {
+	hostVethLink, err := netlink.LinkByName(hostVethName)
+
+	if err != nil {
+		_, notFound := err.(netlink.LinkNotFoundError)
+
+		if !notFound {
+			return nil, nil, fmt.Errorf("failed to find veth %s: %w", hostVethName, err)
+		}
+	}
+
+	hostVeth, ok := hostVethLink.(*netlink.Veth)
+
+	if !ok {
+		return nil, nil, fmt.Errorf("link %s is not veth: %s", hostVethName, hostVethLink.Type())
+	}
+
+	peerVethLink, err := netlink.LinkByName(peerVethName)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find veth %s: %w", peerVethName, err)
+	}
+
+	peerVeth, ok = peerVethLink.(*netlink.Veth)
+
+	if !ok {
+		return nil, nil, fmt.Errorf("link %s is not veth: %s", peerVethName, peerVethLink.Type())
+	}
+
+	return
+}
+
+func setupVeth(hostVethName, peerVethName string) (hostVeth, peerVeth *netlink.Veth, err error) {
+	hostVeth, peerVeth, err = findVeth(hostVethName, peerVethName)
+
+	switch {
+	case err == nil:
+		return hostVeth, peerVeth, nil
+	case errors.Is(err, netlink.LinkNotFoundError{}):
+		hostVethLink := &netlink.Veth{
+			PeerName: peerVethName,
+		}
+
+		if err := netlink.LinkAdd(hostVethLink); err != nil {
+			return nil, nil, fmt.Errorf("faile create a veth %s: %w", hostVethName, err)
+		}
+
+		return findVeth(hostVethName, peerVethName)
+	default:
+		return nil, nil, fmt.Errorf("failed to find %s, %s: %w", hostVethName, peerVethName, err)
+	}
+}
+
+func cmdAdd(args *skel.CmdArgs) error {
+	conf, result, err := loadConfig(args.StdinData)
+
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	hostVeth, peerVeth, err := setupVeth(conf.HostVeth, conf.PeerVeth)
+
+	if err != nil {
+		return fmt.Errorf("failed to set up veth: %w", err)
+	}
+
+	var bridge *netlink.Bridge
+	for _, iface := range result.Interfaces {
+		if iface.Sandbox != "" {
+			continue
+		}
+
+		link, err := netlink.LinkByName(iface.Name)
+
+		if err != nil {
+			return fmt.Errorf("failed to get link %s: %w", iface.Name, err)
+		}
+
+		var ok bool
+		bridge, ok = link.(*netlink.Bridge)
+
+		if ok {
+			break
+		}
+	}
+
+	if bridge == nil {
+		return fmt.Errorf("bridge not found")
+	}
+
+	if err := netlink.LinkSetMaster(hostVeth, bridge); err != nil {
+		return fmt.Errorf("failed to set master of %s %s: %w", hostVeth.Name, bridge.Name, err)
+	}
+
+	for _, ip := range result.IPs {
+		addr, _ := ipaddr.NewIPAddressFromNetIPNet(&ip.Address)
+		cidr, _ := addr.ToZeroHost()
+
+		netlinkAddr := netlink.Addr{
+			IPNet: &net.IPNet{
+				IP:   cidr.GetNetIP(),
+				Mask: net.CIDRMask(cidr.GetPrefixLen().Len(), cidr.GetBitCount()),
+			},
+		}
+
+		if err := netlink.AddrReplace(hostVeth, &netlinkAddr); err != nil {
+			return fmt.Errorf("failed to add an address %s to %s: %w", cidr, hostVeth.Name, err)
+		}
+	}
+
+	if err := setUpFirewall(hostVeth, conf); err != nil {
+		return fmt.Errorf("failed to set up firewall: %w", err)
+	}
+
+	if err := netlink.LinkSetUp(hostVeth); err != nil {
+		return fmt.Errorf("failed to set %s up: %w", hostVeth.Name, err)
+	}
+	if err := netlink.LinkSetUp(peerVeth); err != nil {
+		return fmt.Errorf("failed to set %s up: %w", peerVeth.Name, err)
+	}
+
+	return types.PrintResult(conf.PrevResult, conf.CNIVersion)
+}
+
+func cmdCheck(args *skel.CmdArgs) error {
+	conf, _, err := loadConfig(args.StdinData)
+
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	_, _, err = findVeth(conf.HostVeth, conf.PeerVeth)
+
+	if err != nil {
+		return fmt.Errorf("failed to find veth: %w", err)
+	}
+
+	//TODO(tstsuchi): check firewall rules
+
+	return nil
+}
+
+func cmdDel(args *skel.CmdArgs) error {
+	return nil
+}

--- a/tetracni/cmd/tetra-pod-ipam/param.go
+++ b/tetracni/cmd/tetra-pod-ipam/param.go
@@ -7,16 +7,23 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator"
 	"github.com/miscord-dev/tetrapod/tetrad/pkg/cniserver"
+	"github.com/seancfoley/ipaddress-go/ipaddr"
 )
 
 type IPAM struct {
-	SocketPath string `json:"socketPath"`
-	IPAMPlugin string `json:"ipamPlugin"`
+	SocketPath     string `json:"socketPath"`
+	IPAMPlugin     string `json:"ipamPlugin"`
+	ReserveAddress string `json:"reserve_address"`
 }
 
 type Config struct {
 	IPAM IPAM `json:"ipam"`
 }
+
+const (
+	ReserveAddressLast = "last"
+	ReserveAddressOff  = "off"
+)
 
 func LoadConfig(b []byte) (*allocator.Net, *Config, error) {
 	var net allocator.Net
@@ -34,6 +41,14 @@ func LoadConfig(b []byte) (*allocator.Net, *Config, error) {
 	}
 	if config.IPAM.IPAMPlugin == "" {
 		config.IPAM.IPAMPlugin = "host-local"
+	}
+	switch config.IPAM.ReserveAddress {
+	case "":
+		config.IPAM.ReserveAddress = ReserveAddressLast
+	case ReserveAddressLast, ReserveAddressOff:
+		// ok
+	default:
+		return nil, nil, fmt.Errorf("unknown reserve_address: %s", config.IPAM.ReserveAddress)
 	}
 
 	return &net, &config, nil
@@ -55,9 +70,20 @@ func MutateConfig(netConfig *allocator.Net, config *Config) error {
 			return fmt.Errorf("failed to parse CIDR %s: %w", c.Status.CIDR, err)
 		}
 
+		ipAddr, _ := ipaddr.NewIPAddressFromNetIPNet(cidr)
+		rangeStart := ipAddr.GetLower().Increment(1)
+		rangeEnd := ipAddr.GetUpper().Increment(-1)
+
+		switch config.IPAM.ReserveAddress {
+		case ReserveAddressLast:
+			rangeEnd = rangeEnd.Increment(-1)
+		}
+
 		netConfig.RuntimeConfig.IPRanges = append(netConfig.RuntimeConfig.IPRanges, []allocator.Range{
 			{
-				Subnet: types.IPNet(*cidr),
+				Subnet:     types.IPNet(*cidr),
+				RangeStart: rangeStart.GetNetIP(),
+				RangeEnd:   rangeEnd.GetNetIP(),
 			},
 		})
 	}


### PR DESCRIPTION
Allow agents on hosts like kubelet to access pods via veth.

Connecting to the host from pods is prohibited by iptables.