### PR TITLE
add route pods cni plugin

### DIFF
--- a/tetracni/cmd/route-pods/iptables.go
+++ b/tetracni/cmd/route-pods/iptables.go
@@ -41,14 +41,14 @@ func setUpIPTables(ipt *iptables.IPTables, hostVeth *netlink.Veth, redirectedCha
 	}
 
 	rules := [][]string{
-		{"-o", hostVeth.Name, "-j", "ACCEPT", hostVeth.Name},
+		{"-o", hostVeth.Name, "-j", "ACCEPT"},
 		{"-i", hostVeth.Name, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
 		{"-i", hostVeth.Name, "-j", "REJECT", "--reject-with", "icmp-port-unreachable"},
 	}
 
 	for _, rule := range rules {
 		if err := ipt.AppendUnique(iptablesFilterTable, redirectedChain, rule...); err != nil {
-			return fmt.Errorf("failed to append rules %v to %s/%s", rule, iptablesFilterTable, redirectedChain)
+			return fmt.Errorf("failed to append rules %v to %s/%s: %w", rule, iptablesFilterTable, redirectedChain, err)
 		}
 	}
 

--- a/tetracni/cmd/route-pods/main.go
+++ b/tetracni/cmd/route-pods/main.go
@@ -106,13 +106,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("bridge not found")
 	}
 
-	if err := netlink.LinkSetMaster(hostVeth, bridge); err != nil {
-		return fmt.Errorf("failed to set master of %s %s: %w", hostVeth.Name, bridge.Name, err)
+	if err := netlink.LinkSetMaster(peerVeth, bridge); err != nil {
+		return fmt.Errorf("failed to set master of %s %s: %w", peerVeth.Name, bridge.Name, err)
 	}
 
 	for _, ip := range result.IPs {
 		addr, _ := ipaddr.NewIPAddressFromNetIPNet(&ip.Address)
-		cidr, _ := addr.ToZeroHost()
+		cidr := addr.GetUpper().Increment(-1)
 
 		netlinkAddr := netlink.Addr{
 			IPNet: &net.IPNet{


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
