### PR TITLE
add route pods cni plugin

### DIFF
--- a/tetracni/cmd/route-pods/iptables.go
+++ b/tetracni/cmd/route-pods/iptables.go
@@ -43,7 +43,7 @@ func setUpIPTables(ipt *iptables.IPTables, hostVeth *netlink.Veth, redirectedCha
 	rules := [][]string{
 		{"-o", hostVeth.Name, "-j", "ACCEPT"},
 		{"-i", hostVeth.Name, "-m", "state", "--state", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
-		{"-i", hostVeth.Name, "-j", "REJECT", "--reject-with", "icmp-port-unreachable"},
+		{"-i", hostVeth.Name, "-j", "DROP"},
 	}
 
 	for _, rule := range rules {


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
- Fix a bug
