### PR TITLE
add route pods cni plugin

### DIFF
--- a/tetrad/controllers/extrapodcidrsync_controller.go
+++ b/tetrad/controllers/extrapodcidrsync_controller.go
@@ -180,6 +180,9 @@ func (r *ExtraPodCIDRSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	podHandler := handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
 		pod := o.(*corev1.Pod)
 
+		if pod.Spec.NodeName != r.NodeName {
+			return nil
+		}
 		if pod.Annotations[labels.AnnotationExtraPodCIDRTemplatesKey] == "" {
 			return nil
 		}

--- a/tetrad/pkg/cniserver/cniserver.go
+++ b/tetrad/pkg/cniserver/cniserver.go
@@ -3,6 +3,7 @@ package cniserver
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/rpc"
@@ -174,6 +175,8 @@ func (h *Handler) GetExtraPodCIDRs(args *GetExtraPodCIDRsArgs, cidrClaims *contr
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
+		log.Panic(args.Namespace, args.Name)
+
 		var pod corev1.Pod
 		err := h.localCache.Get(ctx, types.NamespacedName{
 			Namespace: args.Namespace,
@@ -188,6 +191,8 @@ func (h *Handler) GetExtraPodCIDRs(args *GetExtraPodCIDRsArgs, cidrClaims *contr
 		for _, tmpl := range labels.ExtraPODCIDRTemplateNames(pod.Annotations[labels.AnnotationExtraPodCIDRTemplatesKey]) {
 			templateNames[tmpl] = struct{}{}
 		}
+
+		log.Panic(templateNames)
 
 		err = h.cache.List(ctx, cidrClaims, &client.ListOptions{
 			Namespace:     h.controlPlaneNamespace,
@@ -205,6 +210,7 @@ func (h *Handler) GetExtraPodCIDRs(args *GetExtraPodCIDRsArgs, cidrClaims *contr
 			if !generationOK || !statusOK {
 				return fmt.Errorf("extra CIDRClaim %s/%s is not ready", h.controlPlaneNamespace, claim.Name)
 			}
+			log.Panic(claim.Namespace, claim.Name)
 
 			delete(templateNames, claim.Labels[labels.TemplateNameLabelKey])
 		}


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
- Fix a bug
- Fix a bug
- Add debug log
