### PR TITLE
add route pods cni plugin

### DIFF
--- a/tetracni/cmd/tetra-extra-routes/conf.go
+++ b/tetracni/cmd/tetra-extra-routes/conf.go
@@ -41,6 +41,10 @@ func loadConfig(stdin []byte, cniArgs string) (*Conf, *current.Result, error) {
 		return nil, nil, fmt.Errorf("failed to retrieve result: %w", err)
 	}
 
+	if conf.SocketPath == "" {
+		conf.SocketPath = cniserver.DefaultSocketPath
+	}
+
 	var args Args
 	if err := types.LoadArgs(cniArgs, &args); err != nil {
 		return nil, nil, fmt.Errorf("failed to load args: %w", err)

--- a/tetracni/cni/10-tetra.conflist
+++ b/tetracni/cni/10-tetra.conflist
@@ -16,6 +16,10 @@
       "vrf": "tetrapod-vrf"
     },
     {
+      "type": "tetra-extra-routes",
+      "vrf": "tetrapod-vrf"
+    },
+    {
       "type": "route-pods"
     }
   ]


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
- Fix a bug
- Fix a bug
- Add debug log
- Fix bugs
