### PR TITLE
add route pods cni plugin

### DIFF
--- a/tetrad/pkg/cniserver/cniserver.go
+++ b/tetrad/pkg/cniserver/cniserver.go
@@ -3,7 +3,6 @@ package cniserver
 import (
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"net/rpc"
@@ -175,8 +174,6 @@ func (h *Handler) GetExtraPodCIDRs(args *GetExtraPodCIDRsArgs, cidrClaims *contr
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		log.Panic(args.Namespace, args.Name)
-
 		var pod corev1.Pod
 		err := h.localCache.Get(ctx, types.NamespacedName{
 			Namespace: args.Namespace,
@@ -191,8 +188,6 @@ func (h *Handler) GetExtraPodCIDRs(args *GetExtraPodCIDRsArgs, cidrClaims *contr
 		for _, tmpl := range labels.ExtraPODCIDRTemplateNames(pod.Annotations[labels.AnnotationExtraPodCIDRTemplatesKey]) {
 			templateNames[tmpl] = struct{}{}
 		}
-
-		log.Panic(templateNames)
 
 		err = h.cache.List(ctx, cidrClaims, &client.ListOptions{
 			Namespace:     h.controlPlaneNamespace,
@@ -210,7 +205,6 @@ func (h *Handler) GetExtraPodCIDRs(args *GetExtraPodCIDRsArgs, cidrClaims *contr
 			if !generationOK || !statusOK {
 				return fmt.Errorf("extra CIDRClaim %s/%s is not ready", h.controlPlaneNamespace, claim.Name)
 			}
-			log.Panic(claim.Namespace, claim.Name)
 
 			delete(templateNames, claim.Labels[labels.TemplateNameLabelKey])
 		}


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
- Fix a bug
- Fix a bug
- Add debug log
- Fix bugs
- Remove debug log
