### PR TITLE
add route pods cni plugin

### DIFF
--- a/tetrad/config/rbac/kustomization.yaml
+++ b/tetrad/config/rbac/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 # runtime. Be sure to update RoleBinding and ClusterRoleBinding
 # subjects if changing service account names.
 - service_account.yaml
-- role.yaml
+- role_pods.yaml
 - role_binding.yaml
 # - leader_election_role.yaml
 # - leader_election_role_binding.yaml

--- a/tetrad/config/rbac/role_pods.yaml
+++ b/tetrad/config/rbac/role_pods.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: cni-daemon-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
- Fix a bug
- Fix a bug
- Add debug log
- Fix bugs
- Remove debug log
- Fix a bug that unused peers are not deleted
- Support static advertised routes
- Fix rolebinding
