### PR TITLE
set controller ref

### DIFF
--- a/tetrad/controllers/cidrclaimer_controller.go
+++ b/tetrad/controllers/cidrclaimer_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -114,7 +115,7 @@ func (r *CIDRClaimerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		claim.Spec.SizeBit = tmpl.Spec.SizeBit
 
 		if selfNode != nil {
-			return ctrl.SetControllerReference(selfNode, &claim, r.Scheme)
+			return controllerutil.SetOwnerReference(selfNode, &claim, r.Scheme)
 		}
 
 		return nil

--- a/tetrad/controllers/extrapodcidrsync_controller.go
+++ b/tetrad/controllers/extrapodcidrsync_controller.go
@@ -33,6 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -119,7 +120,7 @@ func (r *ExtraPodCIDRSyncReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			claim.Spec.SizeBit = tmpl.Spec.SizeBit
 
 			if selfNode != nil {
-				return ctrl.SetControllerReference(selfNode, &claim, r.Scheme)
+				return controllerutil.SetOwnerReference(selfNode, &claim, r.Scheme)
 			}
 
 			return nil

--- a/tetrad/controllers/extrapodcidrsync_controller.go
+++ b/tetrad/controllers/extrapodcidrsync_controller.go
@@ -77,6 +77,19 @@ func (r *ExtraPodCIDRSyncReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return reconcile.Result{}, fmt.Errorf("failed to get Pod: %w", err)
 	}
 
+	selfNode := &controlplanev1alpha1.PeerNode{}
+	err = r.Get(ctx, types.NamespacedName{
+		Namespace: r.ControlPlaneNamespace,
+		Name:      peerNodeName(r.ClusterName, r.NodeName),
+	}, selfNode)
+
+	switch {
+	case errors.IsNotFound(err):
+		selfNode = nil
+	case err != nil:
+		return reconcile.Result{}, fmt.Errorf("failed to get self PeerNode: %w", err)
+	}
+
 	templateNames := labels.ExtraPODCIDRTemplateNames(pod.Annotations[labels.AnnotationExtraPodCIDRTemplatesKey])
 
 	for _, templateName := range templateNames {
@@ -104,6 +117,10 @@ func (r *ExtraPodCIDRSyncReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 			claim.Spec.Selector = tmpl.Spec.Selector
 			claim.Spec.SizeBit = tmpl.Spec.SizeBit
+
+			if selfNode != nil {
+				return ctrl.SetControllerReference(selfNode, &claim, r.Scheme)
+			}
 
 			return nil
 		})

--- a/tetrad/controllers/peernodesync_controller.go
+++ b/tetrad/controllers/peernodesync_controller.go
@@ -76,7 +76,7 @@ func (r *PeerNodeSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	var peerNode controlplanev1alpha1.PeerNode
 	peerNode.Namespace = r.ControlPlaneNamespace
-	peerNode.Name = fmt.Sprintf("%s-%s", r.ClusterName, r.NodeName)
+	peerNode.Name = peerNodeName(r.ClusterName, r.NodeName)
 
 	_, err := ctrl.CreateOrUpdate(ctx, r.Client, &peerNode, func() error {
 		peerNode.Labels = r.labels()
@@ -112,6 +112,10 @@ func (r *PeerNodeSyncReconciler) labels() map[string]string {
 
 func (r *PeerNodeSyncReconciler) addrsLabels() map[string]string {
 	return labels.NodeTypeForNode(r.ClusterName, r.NodeName)
+}
+
+func peerNodeName(clusterName, nodeName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, nodeName)
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
- Fix a bug
- Fix a bug
- Add debug log
- Fix bugs
- Remove debug log
- Fix a bug that unused peers are not deleted
- Support static advertised routes
- Fix rolebinding
- Set controller references to claims
- Use owner references instead of controller refeerences
