### PR TITLE
print additional fields

### DIFF
--- a/controlplane/api/v1alpha1/cidrblock_types.go
+++ b/controlplane/api/v1alpha1/cidrblock_types.go
@@ -41,6 +41,7 @@ type CIDRBlockStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="CIDR",type=string,JSONPath=`.spec.cidr`
 
 // CIDRBlock is the Schema for the cidrblocks API
 type CIDRBlock struct {

--- a/controlplane/api/v1alpha1/cidrclaim_types.go
+++ b/controlplane/api/v1alpha1/cidrclaim_types.go
@@ -75,6 +75,8 @@ type CIDRClaimStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="CIDR",type=string,JSONPath=`.status.cidr`
+//+kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.state`
 
 // CIDRClaim is the Schema for the cidrclaims API
 type CIDRClaim struct {

--- a/controlplane/config/crd/bases/controlplane.miscord.win_cidrblocks.yaml
+++ b/controlplane/config/crd/bases/controlplane.miscord.win_cidrblocks.yaml
@@ -15,7 +15,11 @@ spec:
     singular: cidrblock
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.cidr
+      name: CIDR
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CIDRBlock is the Schema for the cidrblocks API

--- a/controlplane/config/crd/bases/controlplane.miscord.win_cidrclaims.yaml
+++ b/controlplane/config/crd/bases/controlplane.miscord.win_cidrclaims.yaml
@@ -15,7 +15,14 @@ spec:
     singular: cidrclaim
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.cidr
+      name: CIDR
+      type: string
+    - jsonPath: .status.state
+      name: State
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: CIDRClaim is the Schema for the cidrclaims API


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
- Fix a bug
- Fix a bug
- Add debug log
- Fix bugs
- Remove debug log
- Fix a bug that unused peers are not deleted
- Support static advertised routes
- Fix rolebinding
- Set controller references to claims
- Use owner references instead of controller refeerences
- Print additional fields
