### PR TITLE
optional vrf

### DIFF
--- a/tetrad/api/v1alpha1/cniconfig_types.go
+++ b/tetrad/api/v1alpha1/cniconfig_types.go
@@ -134,6 +134,8 @@ func (wg *Wireguard) Load() {
 	}
 	if wg.VRF == "" {
 		wg.VRF = "tetrapod-vrf"
+	} else if wg.VRF == "-" {
+		wg.VRF = ""
 	}
 	if wg.Table == 0 {
 		wg.Table = 1351


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
- Fix a bug
- Fix a bug
- Add debug log
- Fix bugs
- Remove debug log
- Fix a bug that unused peers are not deleted
- Support static advertised routes
- Fix rolebinding
- Set controller references to claims
- Use owner references instead of controller refeerences
- Print additional fields
- Make VRF for wgengine optional
