### PR TITLE
optional vrf

### DIFF
--- a/tetraengine/wgengine/wgengine.go
+++ b/tetraengine/wgengine/wgengine.go
@@ -23,6 +23,7 @@ func NewVRF(ifaceName, vrf string, table uint32, logger *zap.Logger) (Engine, er
 		ifaceName: ifaceName,
 		vrf:       vrf,
 		table:     table,
+		logger:    logger,
 	}
 
 	wgctrl, err := wgctrl.New()


### PR DESCRIPTION
- Rename toxfu to tetrapod
- Fix Dockerfile
- Add a workflow to build images
- Fix workflow to run on PR
- Fix
- Fix workflow
- Fix config
- Fix bugs
- Add a tag for images with sha
- Add toleration to tetrad config
- Install CNI plugins in image
- Name the workflow to build images
- Install cni automatically
- Make tetrad.Dockerfile build time faster
- Fix bugs
- Cache image build
- Fix cache key
- Fix bugs
- Remove socket before starting the cni server
- Fix config loader
- Fix a bug
- Add a route-pods plugin to configure routes to pods from host
- Fix cni conflict to add route-pods
- Fix bugs
- Fix a bug
- Fix a bug
- Fix a bug
- Fix bugs
- Fix a bug
- Fix a bug
- Add debug log
- Fix bugs
- Remove debug log
- Fix a bug that unused peers are not deleted
- Support static advertised routes
- Fix rolebinding
- Set controller references to claims
- Use owner references instead of controller refeerences
- Print additional fields
- Make VRF for wgengine optional
- Fix bugs
- Continue modifying routes if something went wrong
- Ignore errors as long as possible
- FIx a bug
