### PR TITLE
Use zig to cross compile Docker images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,5 +51,5 @@ jobs:
           context: .
           file: ${{ matrix.component }}.Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,14 +45,6 @@ jobs:
             type=ref,event=pr
             type=sha
       -
-        name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.component }}-${{ matrix.arch }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.component }}-${{ matrix.arch }}-
-      -
         name: Build and push
         uses: docker/build-push-action@v3
         with:
@@ -61,13 +53,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-      -
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
       -
         name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/controlplane.Dockerfile
+++ b/controlplane.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/tetrad.Dockerfile
+++ b/tetrad.Dockerfile
@@ -65,6 +65,8 @@ RUN mkdir -p bin && \
 
 FROM gomod AS tetracni
 
+ARG TARGETARCH
+
 COPY tetracni/ tetracni/
 COPY Makefile Makefile
 

--- a/tetrad.Dockerfile
+++ b/tetrad.Dockerfile
@@ -21,12 +21,12 @@ FROM zigdownloader-${BUILDARCH} AS zigdownloader
 # Prepare for targetarch amd64
 FROM --platform=$BUILDPLATFORM golang:1.19 AS gobase-amd64
 
-ENV ZIGTARGET x86_64-linux-musl
+ENV ZIGTARGET x86_64-linux-gnu
 
 # Prepare for targetarch arm64
 FROM --platform=$BUILDPLATFORM golang:1.19 AS gobase-arm64
 
-ENV ZIGTARGET aarch64-linux-musl
+ENV ZIGTARGET aarch64-linux-gnu
 
 # Build the manager binary
 FROM gobase-${TARGETARCH} AS gomod

--- a/tetrad.Dockerfile
+++ b/tetrad.Dockerfile
@@ -21,15 +21,17 @@ FROM zigdownloader-${BUILDARCH} AS zigdownloader
 # Prepare for targetarch amd64
 FROM --platform=$BUILDPLATFORM golang:1.19 AS gobase-amd64
 
-ENV ZIGTARGET x86_64-linux-gnu
+ENV ZIGTARGET x86_64-linux-musl
 
 # Prepare for targetarch arm64
 FROM --platform=$BUILDPLATFORM golang:1.19 AS gobase-arm64
 
-ENV ZIGTARGET aarch64-linux-gnu
+ENV ZIGTARGET aarch64-linux-musl
 
 # Build the manager binary
 FROM gobase-${TARGETARCH} AS gomod
+
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -57,10 +59,9 @@ ENV PATH $PATH:/zig
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CC="zig cc -target ${ZIGTARGET}" GOOS=linux GOARCH=${TARGETARCH} \
-    mkdir -p bin && \
-    go build -a -o ./bin/tetrad ./tetrad && \
-    go build -a -o ./bin/tetrad-entrypoint ./tetrad/cmd/tetrad-entrypoint
+RUN mkdir -p bin && \
+    GOOS=linux GOARCH=${TARGETARCH} CC="zig cc -target ${ZIGTARGET}" CGO_ENABLED=1 go build -a -o ./bin/tetrad ./tetrad && \
+    GOOS=linux GOARCH=${TARGETARCH} CGO_ENABLED=0                                                                     go build -a -o ./bin/tetrad-entrypoint ./tetrad/cmd/tetrad-entrypoint
 
 FROM gomod AS tetracni
 

--- a/tetrad.Dockerfile
+++ b/tetrad.Dockerfile
@@ -1,5 +1,35 @@
+# Download zig for builarch amd64
+FROM --platform=$BUILDPLATFORM golang:1.19 AS zigdownloader-amd64
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends xz-utils && \
+    curl -LO https://ziglang.org/download/0.10.1/zig-linux-x86_64-0.10.1.tar.xz && \
+    tar xf zig-*.tar.xz && \
+    mv ./zig-*/ /zig/
+
+# Download zig for builarch arm64
+FROM --platform=$BUILDPLATFORM golang:1.19 AS zigdownloader-arm64
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends xz-utils && \
+    curl -LO https://ziglang.org/download/0.10.1/zig-linux-aarch64-0.10.1.tar.xz && \
+    tar xf zig-*.tar.xz && \
+    mv ./zig-*/ /zig/
+
+FROM zigdownloader-${BUILDARCH} AS zigdownloader
+
+# Prepare for targetarch amd64
+FROM --platform=$BUILDPLATFORM golang:1.19 AS gobase-amd64
+
+ENV ZIGTARGET x86_64-linux-gnu
+
+# Prepare for targetarch arm64
+FROM --platform=$BUILDPLATFORM golang:1.19 AS gobase-arm64
+
+ENV ZIGTARGET aarch64-linux-gnu
+
 # Build the manager binary
-FROM golang:1.19 AS gomod
+FROM gobase-${TARGETARCH} AS gomod
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,12 +48,17 @@ COPY tetraengine/ tetraengine/
 
 FROM gomod AS builder
 
+COPY --from=zigdownloader /zig /zig
+
+ENV PATH $PATH:/zig
+
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN mkdir -p bin && \
+RUN CC="zig cc -target ${ZIGTARGET}" GOOS=linux GOARCH=${TARGETARCH} \
+    mkdir -p bin && \
     go build -a -o ./bin/tetrad ./tetrad && \
     go build -a -o ./bin/tetrad-entrypoint ./tetrad/cmd/tetrad-entrypoint
 
@@ -32,7 +67,7 @@ FROM gomod AS tetracni
 COPY tetracni/ tetracni/
 COPY Makefile Makefile
 
-RUN make cni-plugins
+RUN GOOS=linux GOARCH=${TARGETARCH} make cni-plugins
 
 # Fetch CNI plugins
 FROM golang:1.19 AS plugins

--- a/tetrad.Dockerfile
+++ b/tetrad.Dockerfile
@@ -60,8 +60,8 @@ ENV PATH $PATH:/zig
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN mkdir -p bin && \
-    GOOS=linux GOARCH=${TARGETARCH} CC="zig cc -target ${ZIGTARGET}" CGO_ENABLED=1 go build -a -o ./bin/tetrad ./tetrad && \
-    GOOS=linux GOARCH=${TARGETARCH} CGO_ENABLED=0                                                                     go build -a -o ./bin/tetrad-entrypoint ./tetrad/cmd/tetrad-entrypoint
+    GOOS=linux GOARCH=${TARGETARCH} CGO_ENABLED=1 CC="zig cc -target ${ZIGTARGET}" go build -a -o ./bin/tetrad ./tetrad && \
+    GOOS=linux GOARCH=${TARGETARCH} CGO_ENABLED=0                                  go build -a -o ./bin/tetrad-entrypoint ./tetrad/cmd/tetrad-entrypoint
 
 FROM gomod AS tetracni
 


### PR DESCRIPTION
It takes >30mins to build tetrad images for both amd64 and arm64.

Use zig as a cross-platform C compiler and make the build faster.